### PR TITLE
Implement dynamic form app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Reflex Dynamic Form App
+
+This project demonstrates a simple Reflex application that loads form templates from JSON files and stores completed forms in SQLite.
+
+## Folder Structure
+- `forms/` – JSON templates.
+- `database/` – SQLite database file `forms.db`.
+- `scripts/` – Tools such as the Excel VBA macro.
+- `tests/` – Unit tests.
+
+## Running the App
+Install dependencies and run the app:
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+## Excel Template Export
+A VBA module is provided in `scripts/excel_to_json.bas` that exports the active worksheet to a JSON file with the same name as the worksheet. Column A contains field labels. Column B contains either a data type (e.g., `text`, `number`) or a semicolon-separated list for dropdown choices.
+
+## Tests
+Run `pytest` to execute the unit tests.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,61 @@
+import reflex as rx
+from datetime import datetime
+
+from template_loader import load_templates
+from db import save_form, list_forms
+
+class FormState(rx.State):
+    templates = load_templates()
+    selected_template: str = ''
+    form_data: dict = {}
+
+    def select_template(self, template_name: str):
+        self.selected_template = template_name
+        self.form_data = {field['label']: '' for field in self.templates[template_name]['fields']}
+
+    def submit(self):
+        timestamp = datetime.now().isoformat()
+        save_form(self.selected_template, timestamp, self.form_data)
+        self.reset()
+
+    def reset(self):
+        self.selected_template = ''
+        self.form_data = {}
+        FormState.templates = load_templates()
+
+
+def form_fields():
+    tmpl = FormState.templates.get(FormState.selected_template)
+    if not tmpl:
+        return rx.fragment()
+    controls = []
+    for field in tmpl['fields']:
+        label = field['label']
+        if field['type'] == 'dropdown':
+            control = rx.select(field['choices'], on_change=FormState.form_data[label].set)
+        else:
+            control = rx.input(on_change=FormState.form_data[label].set)
+        controls.append(rx.vstack(rx.text(label), control))
+    return rx.vstack(*controls, rx.button('Submit', on_click=FormState.submit))
+
+
+def index() -> rx.Component:
+    forms = list_forms()
+    items = [
+        rx.hstack(rx.text(f"{fid}. {name} @ {ts}")) for fid, name, ts in forms
+    ]
+    add_button = rx.button('Add Form', on_click=lambda: rx.redirect('/add'))
+    return rx.vstack(rx.heading('Completed Forms'), *items, add_button)
+
+
+def add_form() -> rx.Component:
+    options = list(FormState.templates.keys())
+    dropdown = rx.select(options, on_change=FormState.select_template)
+    return rx.vstack(dropdown, form_fields())
+
+app = rx.App()
+app.add_page(index, path='/')
+app.add_page(add_form, path='/add')
+
+if __name__ == '__main__':
+    app.run()

--- a/db.py
+++ b/db.py
@@ -1,0 +1,53 @@
+import sqlite3
+import json
+from pathlib import Path
+
+DB_PATH = Path('database/forms.db')
+DB_PATH.parent.mkdir(exist_ok=True)
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS completed_forms (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    template_name TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    form_json TEXT NOT NULL
+)
+"""
+
+def get_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(CREATE_TABLE_SQL)
+    return conn
+
+def save_form(template_name: str, timestamp: str, data: dict):
+    conn = get_connection()
+    with conn:
+        conn.execute(
+            "INSERT INTO completed_forms (template_name, timestamp, form_json) VALUES (?, ?, ?)",
+            (template_name, timestamp, json.dumps(data)),
+        )
+    conn.close()
+
+def list_forms():
+    conn = get_connection()
+    rows = conn.execute(
+        "SELECT id, template_name, timestamp FROM completed_forms ORDER BY timestamp DESC"
+    ).fetchall()
+    conn.close()
+    return rows
+
+def get_form(form_id: int):
+    conn = get_connection()
+    row = conn.execute(
+        "SELECT template_name, timestamp, form_json FROM completed_forms WHERE id=?",
+        (form_id,),
+    ).fetchone()
+    conn.close()
+    if row:
+        template_name, timestamp, form_json = row
+        return {
+            "template_name": template_name,
+            "timestamp": timestamp,
+            "data": json.loads(form_json),
+        }
+    return None

--- a/forms/example_template.json
+++ b/forms/example_template.json
@@ -1,0 +1,9 @@
+{
+  "name": "ExampleForm",
+  "description": "A sample form template",
+  "fields": [
+    {"label": "Name", "type": "text"},
+    {"label": "Age", "type": "number"},
+    {"label": "Favorite Color", "type": "dropdown", "choices": ["Red", "Green", "Blue"]}
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+reflex
+pytest

--- a/scripts/excel_to_json.bas
+++ b/scripts/excel_to_json.bas
@@ -1,0 +1,32 @@
+Sub WorksheetToJson()
+    Dim ws As Worksheet
+    Dim json As String
+    Dim i As Integer
+    Set ws = ActiveSheet
+    json = "{\n  \"name\": \"" & ws.Name & "\",\n  \"description\": \"" & ws.Range("A1").Value & "\",\n  \"fields\": ["
+    i = 2
+    Do While ws.Cells(i, 1).Value <> ""
+        json = json & "{\"label\": \"" & ws.Cells(i, 1).Value & "\""
+        If ws.Cells(i, 2).Value Like "*;*" Then
+            json = json & ", \"type\": \"dropdown\", \"choices\": ["
+            Dim parts As Variant
+            parts = Split(ws.Cells(i, 2).Value, ";")
+            Dim j As Integer
+            For j = LBound(parts) To UBound(parts)
+                json = json & "\"" & Trim(parts(j)) & "\""
+                If j < UBound(parts) Then json = json & ", "
+            Next j
+            json = json & "]}"
+        Else
+            json = json & ", \"type\": \"" & ws.Cells(i, 2).Value & "\"}"
+        End If
+        i = i + 1
+        If ws.Cells(i, 1).Value <> "" Then json = json & ","
+    Loop
+    json = json & "]\n}"
+    Dim fso As Object, fileOut As Object
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Set fileOut = fso.CreateTextFile(ws.Name & ".json", True)
+    fileOut.Write json
+    fileOut.Close
+End Sub

--- a/template_loader.py
+++ b/template_loader.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+
+TEMPLATE_DIR = Path('forms')
+
+
+def load_templates():
+    templates = {}
+    for path in TEMPLATE_DIR.glob('*.json'):
+        with open(path, 'r') as f:
+            data = json.load(f)
+            templates[data['name']] = data
+    return templates

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,17 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+from db import save_form, list_forms, get_form, DB_PATH
+
+
+def test_db_operations(tmp_path, monkeypatch):
+    test_db = tmp_path / 'test.db'
+    monkeypatch.setattr('db.DB_PATH', test_db)
+
+    save_form('TestTemplate', '2023', {'a': 1})
+    forms = list_forms()
+    assert len(forms) == 1
+    form_id, name, ts = forms[0]
+    assert name == 'TestTemplate'
+
+    form = get_form(form_id)
+    assert form['data'] == {'a': 1}

--- a/tests/test_template_loader.py
+++ b/tests/test_template_loader.py
@@ -1,0 +1,11 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from template_loader import load_templates
+
+def test_load_templates(tmp_path, monkeypatch):
+    # create sample template
+    sample = tmp_path / "sample.json"
+    sample.write_text('{"name": "Test", "description": "test", "fields": []}')
+    monkeypatch.setattr('template_loader.TEMPLATE_DIR', tmp_path)
+    templates = load_templates()
+    assert 'Test' in templates
+    assert templates['Test']['description'] == 'test'


### PR DESCRIPTION
## Summary
- add example form template and requirements
- load form templates from JSON files
- store completed forms in an sqlite database
- add Reflex app skeleton for listing and adding forms
- provide Excel VBA macro for exporting templates
- add unit tests for template loader and DB helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e94c2b30832ca40e10b63bcd0662