### PR TITLE
Fix naming conflict with Reflex built‑in

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -16,9 +16,10 @@ class FormState(rx.State):
     def submit(self):
         timestamp = datetime.now().isoformat()
         save_form(self.selected_template, timestamp, self.form_data)
-        self.reset()
+        self.reset_state()
 
-    def reset(self):
+    def reset_state(self):
+        """Clear the currently selected template and reload templates."""
         self.selected_template = ''
         self.form_data = {}
         FormState.templates = load_templates()


### PR DESCRIPTION
## Summary
- rename `reset` method that conflicted with Reflex built‑in

## Testing
- `pytest -q`
- `reflex run` *(fails: App.add_page() got an unexpected keyword argument 'path')*

------
https://chatgpt.com/codex/tasks/task_e_688b74989630832c94f48f0ed0680b6b