### PR TITLE
Fix template lookup path

### DIFF
--- a/app/template_loader.py
+++ b/app/template_loader.py
@@ -1,7 +1,11 @@
+"""Utility for loading form templates from JSON files."""
+
 import json
 from pathlib import Path
 
-TEMPLATE_DIR = Path('forms')
+# Locate the ``forms`` directory relative to this file so the app can be
+# executed from any working directory.
+TEMPLATE_DIR = Path(__file__).parent / "forms"
 
 
 def load_templates():


### PR DESCRIPTION
## Summary
- load form templates relative to `template_loader.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7bcf1578832c8e5bdeb2e294738a