### PR TITLE
Implement template-based form editing

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,34 +3,55 @@ from datetime import datetime
 from typing import ClassVar
 
 from app.template_loader import load_templates
-from app.db import save_form, list_forms
+from app.db import save_form, list_forms, get_form, update_form
 
 class FormState(rx.State):
     templates: ClassVar[dict] = load_templates()
     selected_template: str = ""
     form_data: dict[str, str] = {}
+    editing_id: int | None = None
 
-    def select_template(self, template_name: str) -> None:
-        """Choose a template and initialize blank form data."""
+    def start_new_form(self, template_name: str):
+        """Begin a new form based on the given template."""
         self.selected_template = template_name
+        self.editing_id = None
         self.form_data = {
             field["label"]: "" for field in self.templates[template_name]["fields"]
         }
+        return rx.redirect("/fill")
+
+    def load_form(self, form_id: int):
+        """Load an existing form for editing."""
+        form = get_form(form_id)
+        if not form:
+            return
+        self.selected_template = form["template_name"]
+        self.editing_id = form_id
+        tmpl_fields = self.templates[self.selected_template]["fields"]
+        self.form_data = {
+            f["label"]: form["data"].get(f["label"], "") for f in tmpl_fields
+        }
+        return rx.redirect("/fill")
 
     def update_field(self, field_name: str, value: str) -> None:
         """Update a single field in the form data."""
         self.form_data[field_name] = value
 
     def submit(self) -> None:
-        """Save the current form to the database and reset."""
+        """Save or update the current form in the database and reset."""
         timestamp = datetime.now().isoformat()
-        save_form(self.selected_template, timestamp, self.form_data)
+        if self.editing_id is None:
+            save_form(self.selected_template, timestamp, self.form_data)
+        else:
+            update_form(self.editing_id, self.selected_template, timestamp, self.form_data)
         self.reset_state()
+        return rx.redirect("/")
 
     def reset_state(self) -> None:
         """Clear the currently selected template and reload templates."""
         self.selected_template = ""
         self.form_data = {}
+        self.editing_id = None
         FormState.templates = load_templates()
 
 
@@ -56,20 +77,25 @@ def form_fields():
 
 def index() -> rx.Component:
     forms = list_forms()
-    items = [
-        rx.hstack(rx.text(f"{fid}. {name} @ {ts}")) for fid, name, ts in forms
-    ]
+    items = []
+    for fid, name, ts in forms:
+        edit_btn = rx.button('Edit', on_click=lambda f=fid: FormState.load_form(f))
+        items.append(rx.hstack(rx.text(f"{fid}. {name} @ {ts}"), edit_btn))
     add_button = rx.button('Add Form', on_click=lambda: rx.redirect('/add'))
     return rx.vstack(rx.heading('Completed Forms'), *items, add_button)
 
 
 def add_form() -> rx.Component:
-    dropdown = rx.select(FormState.templates.keys(), on_change=FormState.select_template)
-    return rx.vstack(dropdown, form_fields())
+    dropdown = rx.select(FormState.templates.keys(), on_change=FormState.start_new_form)
+    return rx.vstack(dropdown)
+
+def fill_form() -> rx.Component:
+    return rx.vstack(form_fields())
 
 app = rx.App()
 app.add_page(index, route='/')
 app.add_page(add_form, route='/add')
+app.add_page(fill_form, route='/fill')
 
 if __name__ == '__main__':
     app.run()

--- a/app/db.py
+++ b/app/db.py
@@ -51,3 +51,13 @@ def get_form(form_id: int):
             "data": json.loads(form_json),
         }
     return None
+
+def update_form(form_id: int, template_name: str, timestamp: str, data: dict):
+    """Update an existing form record."""
+    conn = get_connection()
+    with conn:
+        conn.execute(
+            "UPDATE completed_forms SET template_name=?, timestamp=?, form_json=? WHERE id=?",
+            (template_name, timestamp, json.dumps(data), form_id),
+        )
+    conn.close()

--- a/app/tests/test_db.py
+++ b/app/tests/test_db.py
@@ -1,6 +1,6 @@
 import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import os
-from db import save_form, list_forms, get_form, DB_PATH
+from db import save_form, list_forms, get_form, update_form, DB_PATH
 
 
 def test_db_operations(tmp_path, monkeypatch):
@@ -15,3 +15,14 @@ def test_db_operations(tmp_path, monkeypatch):
 
     form = get_form(form_id)
     assert form['data'] == {'a': 1}
+
+def test_update_form(tmp_path, monkeypatch):
+    test_db = tmp_path / 'test.db'
+    monkeypatch.setattr('db.DB_PATH', test_db)
+
+    save_form('Temp', '2023', {'a': 1})
+    form_id = list_forms()[0][0]
+    update_form(form_id, 'Temp', '2024', {'a': 2})
+    form = get_form(form_id)
+    assert form['data'] == {'a': 2}
+    assert form['timestamp'] == '2024'


### PR DESCRIPTION
## Summary
- add `update_form` helper for editing records
- enable start/edit workflows in `FormState`
- load new form page after template selection
- provide edit button on the index page
- test updating the database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b81dfd970832c811844f155830532