### PR TITLE
Replace dropdown template selector with buttons

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -78,8 +78,19 @@ def index() -> rx.Component:
 
 
 def add_form() -> rx.Component:
-    dropdown = rx.select(FormState.templates.keys(), on_change=FormState.select_template)
-    content = rx.vstack(dropdown, form_fields())
+    """Page for selecting a template and displaying its form."""
+    template_rows = []
+    for name in FormState.templates.keys():
+        template_rows.append(
+            rx.hstack(
+                rx.text(name),
+                rx.button(
+                    "Use this",
+                    on_click=lambda n=name: FormState.select_template(n),
+                ),
+            )
+        )
+    content = rx.vstack(*template_rows, form_fields())
     return layout(content)
 
 app = rx.App()


### PR DESCRIPTION
## Summary
- Update the add form page to show a list of templates
- Each template has a "Use this" button that selects the template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b85e3a140832c94ccbc25f8692d55