### PR TITLE
Fix fill page layout

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -116,7 +116,12 @@ def add_form() -> rx.Component:
     return layout(content)
 
 def fill_form() -> rx.Component:
-    return rx.vstack(form_fields())
+    """Page for filling out the currently selected template."""
+    content = rx.vstack(
+        rx.heading(FormState.selected_template or "Fill Form"),
+        form_fields(),
+    )
+    return layout(content)
 
 
 app = rx.App()


### PR DESCRIPTION
## Summary
- ensure fill page uses layout header
- show template name as heading on the fill page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8e7f56d8832cb71afae3bdf2c1ca