### PR TITLE
Fix dynamic heading for selected form

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -118,7 +118,13 @@ def add_form() -> rx.Component:
 def fill_form() -> rx.Component:
     """Page for filling out the currently selected template."""
     content = rx.vstack(
-        rx.heading(FormState.selected_template or "Fill Form"),
+        rx.heading(
+            rx.cond(
+                FormState.selected_template != "",
+                FormState.selected_template,
+                "Fill Form",
+            )
+        ),
         form_fields(),
     )
     return layout(content)


### PR DESCRIPTION
## Summary
- avoid using `or` with reactive Vars in `fill_form`
- use `rx.cond` to display form heading based on selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8fc8ff50832c892beddacfdb3172