### PR TITLE
Fix event handlers

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -92,7 +92,12 @@ def index() -> rx.Component:
     forms = list_forms()
     items = []
     for fid, name, ts in forms:
-        edit_btn = rx.button('Edit', on_click=lambda _, f=fid: FormState.load_form(f))
+        edit_btn = rx.button(
+            "Edit",
+            # Reflex on_click handlers do not receive any arguments, so we wrap
+            # the form ID using a default parameter.
+            on_click=lambda f=fid: FormState.load_form(f),
+        )
         items.append(rx.hstack(rx.text(f"{fid}. {name} @ {ts}"), edit_btn))
     add_button = rx.button('Add Form', on_click=lambda: rx.redirect('/add'))
     content = rx.vstack(rx.heading('Completed Forms'), *items, add_button)
@@ -108,7 +113,9 @@ def add_form() -> rx.Component:
                 rx.text(name),
                 rx.button(
                     "Use this",
-                    on_click=lambda _, n=name: FormState.start_new_form(n),
+                    # The on_click event provides no arguments; capture the name
+                    # with a default parameter instead of expecting a parameter.
+                    on_click=lambda n=name: FormState.start_new_form(n),
                 ),
             )
         )


### PR DESCRIPTION
## Summary
- fix event handler signatures for new reflex
- update "Edit" and "Use this" buttons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ba03728ec832ca005a26ab7678884