### PR TITLE
Fix Reflex event handlers

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -85,8 +85,8 @@ def layout(*content: rx.Component) -> rx.Component:
     header = rx.hstack(
         rx.heading("Dynamic Form App"),
         rx.spacer(),
-        rx.button("Home", on_click=lambda _: rx.redirect("/")),
-        rx.button("Add Form", on_click=lambda _: rx.redirect("/add")),
+        rx.button("Home", on_click=lambda: rx.redirect("/")),
+        rx.button("Add Form", on_click=lambda: rx.redirect("/add")),
         padding="1em",
     )
     body = rx.box(*content, padding="1em")
@@ -100,12 +100,12 @@ def index() -> rx.Component:
     for fid, name, ts in forms:
         edit_btn = rx.button(
             "Edit",
-            # Reflex on_click handlers do not receive any arguments, so we wrap
+            # Reflex on_click handlers do not provide arguments, so capture
             # the form ID using a default parameter.
-            on_click=lambda _, f=fid: FormState.load_form(f),
+            on_click=lambda f=fid: FormState.load_form(f),
         )
         items.append(rx.hstack(rx.text(f"{fid}. {name} @ {ts}"), edit_btn))
-    add_button = rx.button('Add Form', on_click=lambda _: rx.redirect('/add'))
+    add_button = rx.button('Add Form', on_click=lambda: rx.redirect('/add'))
     content = rx.vstack(rx.heading('Completed Forms'), *items, add_button)
     return layout(content)
 
@@ -122,7 +122,7 @@ def add_form() -> rx.Component:
                     "Use this",
                     # The on_click event provides no arguments; capture the name
                     # with a default parameter instead of expecting a parameter.
-                    on_click=lambda _, n=name: FormState.start_new_form(n),
+                    on_click=lambda n=name: FormState.start_new_form(n),
                 ),
             )
         )


### PR DESCRIPTION
## Summary
- adjust button `on_click` handlers to not expect arguments

## Testing
- `pytest -q`
- `reflex run`

------
https://chatgpt.com/codex/tasks/task_e_688babf71054832cb4dccb3099d3e638